### PR TITLE
fix(webpack): remove chunk name comment, define chunkname in webpack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Project Changelog
 
+## [1.7.1](https://github.com/GrabarzUndPartner/nuxt-custom-elements/compare/v1.7.0...v1.7.1) (2021-07-09)
+
+
+### Bug Fixes
+
+* **module:** fix deprecated warning ([50056e7](https://github.com/GrabarzUndPartner/nuxt-custom-elements/commit/50056e7f90661147aab9583709e0cbd30be1ddf8))
+
 # [1.7.0](https://github.com/GrabarzUndPartner/nuxt-custom-elements/compare/v1.6.2...v1.7.0) (2021-07-06)
 
 

--- a/lib/tmpl/entry.js
+++ b/lib/tmpl/entry.js
@@ -23,7 +23,7 @@ Vue.use(VueCustomElement);
     options = JSON.stringify(options)
   }
 if (async) {
-  %><%= `Vue.customElement('${name}', () => { return import(/* webpackChunkName: "${name}" */ '${path}').then(module => (typeof module.default === 'function' ? (new module.default).$options : module.default) ); }, ${options});\n` %><%
+  %><%= `Vue.customElement('${name}', () => { return import('${path}').then(module => (typeof module.default === 'function' ? (new module.default).$options : module.default) ); }, ${options});\n` %><%
 
 } else {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-custom-elements",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Publish your Components as a vue-custom-element standalone build.",
   "keywords": [
     "nuxtjs",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Chunkname was defined in the template.

Problem: Overwrites the module webpack config and creates too long chunknames.

Example: `vendors~############~#############~############~93db26c3.5fc54f866453d3227885.js`

* **What is the new behavior (if this is a feature change)?**

Module Webpack Chunkname Configuration takes effect.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
